### PR TITLE
#17 : Fixed notices when there are no existing tabs on the event detail page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All Notable changes to **CultureFeed Lists**.
 
 
 
+## [Unreleased]
+### Fixed
+* #17 : Fixed notices when there are no existing tabs on the event detail page.
+
+
+
 
 ## [7.x-1.0-beta2] - 2017-06-12
 ### Added

--- a/culturefeed_lists.module
+++ b/culturefeed_lists.module
@@ -289,6 +289,11 @@ function culturefeed_lists_menu_local_tasks_alter(array &$data, $router_item, $r
     );
   }
 
+  // Make sure that we can add tabs, even if the item itself has no other tabs.
+  if (!isset($data['tabs'][0]['count'])) {
+    $data['tabs'][0]['output'] = array();
+    $data['tabs'][0]['count'] = 0;
+  }
   $data['tabs'][0]['output'] = array_merge($data['tabs'][0]['output'], $tabs);
   $data['tabs'][0]['count'] += count($tabs);
 }


### PR DESCRIPTION
See #17.